### PR TITLE
chore(readme):fixed typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Used as namespace for providing persistence utils.
 // ExampleStore.ts
 import {Store} from "educe";
 
-interfance IExampleStoreState {
+interface IExampleStoreState {
     count: number;
 }
 


### PR DESCRIPTION
Fixed a typo in the Basic Store Example Usage (interfance => interface)